### PR TITLE
fix: Support negative values for ulimits

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,7 @@ locals {
   # re2 ASCII character classes
   # https://github.com/google/re2/wiki/Syntax
   classes = {
-    digit = "/\"([[:digit:]]+)\"/"
+    digit = "/\"(-[[:digit:]]|[[:digit:]]+)\"/"
   }
 
   container_definitions = "${replace(data.template_file.container_definitions.rendered, "/\"(null)\"/", "$1")}"


### PR DESCRIPTION
Adds support for negative numerical values in ECS task definitions, particularly [`ulimit`](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Ulimit.html) configurations.