### PR TITLE
feat: Add register_task_definition input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -142,4 +142,6 @@ resource "aws_ecs_task_definition" "ecs_task_definition" {
   requires_compatibilities = "${var.requires_compatibilities}"
   task_role_arn            = "${var.task_role_arn}"
   volume                   = "${var.volumes}"
+
+  count = "${var.register_task_definition ? 1 : 0}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "arn" {
   description = "The full Amazon Resource Name (ARN) of the task definition"
-  value       = "${aws_ecs_task_definition.ecs_task_definition.arn}"
+  value       = "${join("", aws_ecs_task_definition.ecs_task_definition.*.arn)}"
 }
 
 output "container_definitions" {
@@ -10,10 +10,10 @@ output "container_definitions" {
 
 output "family" {
   description = "The family of your task definition, used as the definition name"
-  value       = "${aws_ecs_task_definition.ecs_task_definition.family}"
+  value       = "${join("", aws_ecs_task_definition.ecs_task_definition.*.family)}"
 }
 
 output "revision" {
   description = "The revision of the task in a particular family"
-  value       = "${aws_ecs_task_definition.ecs_task_definition.revision}"
+  value       = "${join("", aws_ecs_task_definition.ecs_task_definition.*.revision)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -175,6 +175,11 @@ variable "readonlyRootFilesystem" {
   description = "When this parameter is true, the container is given read-only access to its root file system"
 }
 
+variable "register_task_definition" {
+  default     = true
+  description = "Registers a new task definition from the supplied family and containerDefinitions"
+}
+
 variable "repositoryCredentials" {
   default     = {}
   description = "The private repository authentication credentials to use"


### PR DESCRIPTION
Provides a flag for specifying whether to create the ECS Task Definition or not.