### PR TITLE
feat: upgrade module to support Terraform 0.12.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ jobs:
       - go/save-cache
       - run:
           command: |
-            wget --quiet https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-            sudo unzip terraform_0.11.14_linux_amd64.zip -d /usr/local/bin
+            wget --quiet https://releases.hashicorp.com/terraform/0.12.23/terraform_0.12.23_linux_amd64.zip
+            sudo unzip terraform_0.12.23_linux_amd64.zip -d /usr/local/bin
           name: Install Terraform
       - go/test
   release:

--- a/README.md
+++ b/README.md
@@ -102,55 +102,62 @@ Invoking the commands defined below creates an ECS task definition with the foll
 By default, this module creates a task definition with a single container definition. To create a task definition with multiple container definitions, refer to the documentation of the [`merge`](modules/merge) module.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| template | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| command | The command that is passed to the container | list | `[]` | no |
-| cpu | The number of cpu units reserved for the container | string | `"0"` | no |
-| disableNetworking | When this parameter is true, networking is disabled within the container | string | `"false"` | no |
-| dnsSearchDomains | A list of DNS search domains that are presented to the container | list | `[]` | no |
-| dnsServers | A list of DNS servers that are presented to the container | list | `[]` | no |
-| dockerLabels | A key/value map of labels to add to the container | map | `{}` | no |
-| dockerSecurityOptions | A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems | list | `[]` | no |
-| entryPoint | The entry point that is passed to the container | list | `[]` | no |
-| environment | The environment variables to pass to a container | list | `[]` | no |
-| essential | If the essential parameter of a container is marked as true, and that container fails or stops for any reason, all other containers that are part of the task are stopped | string | `"true"` | no |
-| execution\_role\_arn | The Amazon Resource Name (ARN) of the task execution role that the Amazon ECS container agent and the Docker daemon can assume | string | `""` | no |
-| extraHosts | A list of hostnames and IP address mappings to append to the /etc/hosts file on the container | list | `[]` | no |
-| family | You must specify a family for a task definition, which allows you to track multiple versions of the same task definition | string | n/a | yes |
-| healthCheck | The health check command and associated configuration parameters for the container | map | `{}` | no |
-| hostname | The hostname to use for your container | string | `""` | no |
-| image | The image used to start a container | string | `""` | no |
-| interactive | When this parameter is true, this allows you to deploy containerized applications that require stdin or a tty to be allocated | string | `"false"` | no |
-| ipc\_mode | The IPC resource namespace to use for the containers in the task | string | `"host"` | no |
-| links | The link parameter allows containers to communicate with each other without the need for port mappings | list | `[]` | no |
-| linuxParameters | Linux-specific modifications that are applied to the container, such as Linux KernelCapabilities | map | `{}` | no |
-| logConfiguration | The log configuration specification for the container | map | `{}` | no |
-| memory | The hard limit (in MiB) of memory to present to the container | string | `"0"` | no |
-| memoryReservation | The soft limit (in MiB) of memory to reserve for the container | string | `"0"` | no |
-| mountPoints | The mount points for data volumes in your container | list | `[]` | no |
-| name | The name of a container | string | `""` | no |
-| network\_mode | The Docker networking mode to use for the containers in the task | string | `"bridge"` | no |
-| pid\_mode | The process namespace to use for the containers in the task | string | `"host"` | no |
-| placement\_constraints | An array of placement constraint objects to use for the task | list | `[]` | no |
-| portMappings | The list of port mappings for the container | list | `[]` | no |
-| privileged | When this parameter is true, the container is given elevated privileges on the host container instance (similar to the root user) | string | `"false"` | no |
-| pseudoTerminal | When this parameter is true, a TTY is allocated | string | `"false"` | no |
-| readonlyRootFilesystem | When this parameter is true, the container is given read-only access to its root file system | string | `"false"` | no |
-| register\_task\_definition | Registers a new task definition from the supplied family and containerDefinitions | string | `"true"` | no |
-| repositoryCredentials | The private repository authentication credentials to use | map | `{}` | no |
-| requires\_compatibilities | The launch type required by the task | list | `[]` | no |
-| resourceRequirements | The type and amount of a resource to assign to a container | list | `[]` | no |
-| secrets | The secrets to pass to the container | list | `[]` | no |
-| systemControls | A list of namespaced kernel parameters to set in the container | list | `[]` | no |
-| tags | The metadata that you apply to the task definition to help you categorize and organize them | map | `{}` | no |
-| task\_role\_arn | The short name or full Amazon Resource Name (ARN) of the IAM role that containers in this task can assume | string | `""` | no |
-| ulimits | A list of ulimits to set in the container | list | `[]` | no |
-| user | The user name to use inside the container | string | `""` | no |
-| volumes | A list of volume definitions in JSON format that containers in your task may use | list | `[]` | no |
-| volumesFrom | Data volumes to mount from another container | list | `[]` | no |
-| workingDirectory | The working directory in which to run commands inside the container | string | `""` | no |
+|------|-------------|------|---------|:-----:|
+| command | The command that is passed to the container | `list(string)` | `[]` | no |
+| cpu | The number of cpu units reserved for the container | `number` | `0` | no |
+| disableNetworking | When this parameter is true, networking is disabled within the container | `bool` | `false` | no |
+| dnsSearchDomains | A list of DNS search domains that are presented to the container | `list(string)` | `[]` | no |
+| dnsServers | A list of DNS servers that are presented to the container | `list(string)` | `[]` | no |
+| dockerLabels | A key/value map of labels to add to the container | `map(string)` | `{}` | no |
+| dockerSecurityOptions | A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems | `list(string)` | `[]` | no |
+| entryPoint | The entry point that is passed to the container | `list(string)` | `[]` | no |
+| environment | The environment variables to pass to a container | `list(string)` | `[]` | no |
+| essential | If the essential parameter of a container is marked as true, and that container fails or stops for any reason, all other containers that are part of the task are stopped | `bool` | `true` | no |
+| execution\_role\_arn | The Amazon Resource Name (ARN) of the task execution role that the Amazon ECS container agent and the Docker daemon can assume | `string` | `""` | no |
+| extraHosts | A list of hostnames and IP address mappings to append to the /etc/hosts file on the container | `list(string)` | `[]` | no |
+| family | You must specify a family for a task definition, which allows you to track multiple versions of the same task definition | `any` | n/a | yes |
+| healthCheck | The health check command and associated configuration parameters for the container | `map(string)` | `{}` | no |
+| hostname | The hostname to use for your container | `string` | `""` | no |
+| image | The image used to start a container | `string` | `""` | no |
+| interactive | When this parameter is true, this allows you to deploy containerized applications that require stdin or a tty to be allocated | `bool` | `false` | no |
+| ipc\_mode | The IPC resource namespace to use for the containers in the task | `string` | `"host"` | no |
+| links | The link parameter allows containers to communicate with each other without the need for port mappings | `list(string)` | `[]` | no |
+| linuxParameters | Linux-specific modifications that are applied to the container, such as Linux KernelCapabilities | `map(string)` | `{}` | no |
+| logConfiguration | The log configuration specification for the container | `map(string)` | `{}` | no |
+| memory | The hard limit (in MiB) of memory to present to the container | `number` | `0` | no |
+| memoryReservation | The soft limit (in MiB) of memory to reserve for the container | `number` | `0` | no |
+| mountPoints | The mount points for data volumes in your container | `list(string)` | `[]` | no |
+| name | The name of a container | `string` | `""` | no |
+| network\_mode | The Docker networking mode to use for the containers in the task | `string` | `"bridge"` | no |
+| pid\_mode | The process namespace to use for the containers in the task | `string` | `"host"` | no |
+| placement\_constraints | An array of placement constraint objects to use for the task | `list(string)` | `[]` | no |
+| portMappings | The list of port mappings for the container | `list(string)` | `[]` | no |
+| privileged | When this parameter is true, the container is given elevated privileges on the host container instance (similar to the root user) | `bool` | `false` | no |
+| pseudoTerminal | When this parameter is true, a TTY is allocated | `bool` | `false` | no |
+| readonlyRootFilesystem | When this parameter is true, the container is given read-only access to its root file system | `bool` | `false` | no |
+| register\_task\_definition | Registers a new task definition from the supplied family and containerDefinitions | `bool` | `true` | no |
+| repositoryCredentials | The private repository authentication credentials to use | `map(string)` | `{}` | no |
+| requires\_compatibilities | The launch type required by the task | `list(string)` | `[]` | no |
+| resourceRequirements | The type and amount of a resource to assign to a container | `list(string)` | `[]` | no |
+| secrets | The secrets to pass to the container | `list(string)` | `[]` | no |
+| systemControls | A list of namespaced kernel parameters to set in the container | `list(string)` | `[]` | no |
+| tags | The metadata that you apply to the task definition to help you categorize and organize them | `map(string)` | `{}` | no |
+| task\_role\_arn | The short name or full Amazon Resource Name (ARN) of the IAM role that containers in this task can assume | `string` | `""` | no |
+| ulimits | A list of ulimits to set in the container | `list(string)` | `[]` | no |
+| user | The user name to use inside the container | `string` | `""` | no |
+| volumes | A list of volume definitions in JSON format that containers in your task may use | `list(string)` | `[]` | no |
+| volumesFrom | Data volumes to mount from another container | `list(string)` | `[]` | no |
+| workingDirectory | The working directory in which to run commands inside the container | `string` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -121,27 +121,27 @@ By default, this module creates a task definition with a single container defini
 | dockerLabels | A key/value map of labels to add to the container | `map(string)` | `{}` | no |
 | dockerSecurityOptions | A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems | `list(string)` | `[]` | no |
 | entryPoint | The entry point that is passed to the container | `list(string)` | `[]` | no |
-| environment | The environment variables to pass to a container | `list(string)` | `[]` | no |
+| environment | The environment variables to pass to a container | `list(map(string))` | `[]` | no |
 | essential | If the essential parameter of a container is marked as true, and that container fails or stops for any reason, all other containers that are part of the task are stopped | `bool` | `true` | no |
 | execution\_role\_arn | The Amazon Resource Name (ARN) of the task execution role that the Amazon ECS container agent and the Docker daemon can assume | `string` | `""` | no |
 | extraHosts | A list of hostnames and IP address mappings to append to the /etc/hosts file on the container | `list(string)` | `[]` | no |
 | family | You must specify a family for a task definition, which allows you to track multiple versions of the same task definition | `any` | n/a | yes |
-| healthCheck | The health check command and associated configuration parameters for the container | `map(string)` | `{}` | no |
+| healthCheck | The health check command and associated configuration parameters for the container | `any` | `{}` | no |
 | hostname | The hostname to use for your container | `string` | `""` | no |
 | image | The image used to start a container | `string` | `""` | no |
 | interactive | When this parameter is true, this allows you to deploy containerized applications that require stdin or a tty to be allocated | `bool` | `false` | no |
 | ipc\_mode | The IPC resource namespace to use for the containers in the task | `string` | `"host"` | no |
 | links | The link parameter allows containers to communicate with each other without the need for port mappings | `list(string)` | `[]` | no |
-| linuxParameters | Linux-specific modifications that are applied to the container, such as Linux KernelCapabilities | `map(string)` | `{}` | no |
+| linuxParameters | Linux-specific modifications that are applied to the container, such as Linux KernelCapabilities | `any` | `{}` | no |
 | logConfiguration | The log configuration specification for the container | `map(string)` | `{}` | no |
 | memory | The hard limit (in MiB) of memory to present to the container | `number` | `0` | no |
 | memoryReservation | The soft limit (in MiB) of memory to reserve for the container | `number` | `0` | no |
-| mountPoints | The mount points for data volumes in your container | `list(string)` | `[]` | no |
+| mountPoints | The mount points for data volumes in your container | `list(any)` | `[]` | no |
 | name | The name of a container | `string` | `""` | no |
 | network\_mode | The Docker networking mode to use for the containers in the task | `string` | `"bridge"` | no |
 | pid\_mode | The process namespace to use for the containers in the task | `string` | `"host"` | no |
 | placement\_constraints | An array of placement constraint objects to use for the task | `list(string)` | `[]` | no |
-| portMappings | The list of port mappings for the container | `list(string)` | `[]` | no |
+| portMappings | The list of port mappings for the container | `list(any)` | `[]` | no |
 | privileged | When this parameter is true, the container is given elevated privileges on the host container instance (similar to the root user) | `bool` | `false` | no |
 | pseudoTerminal | When this parameter is true, a TTY is allocated | `bool` | `false` | no |
 | readonlyRootFilesystem | When this parameter is true, the container is given read-only access to its root file system | `bool` | `false` | no |
@@ -153,9 +153,9 @@ By default, this module creates a task definition with a single container defini
 | systemControls | A list of namespaced kernel parameters to set in the container | `list(string)` | `[]` | no |
 | tags | The metadata that you apply to the task definition to help you categorize and organize them | `map(string)` | `{}` | no |
 | task\_role\_arn | The short name or full Amazon Resource Name (ARN) of the IAM role that containers in this task can assume | `string` | `""` | no |
-| ulimits | A list of ulimits to set in the container | `list(string)` | `[]` | no |
+| ulimits | A list of ulimits to set in the container | `list(any)` | `[]` | no |
 | user | The user name to use inside the container | `string` | `""` | no |
-| volumes | A list of volume definitions in JSON format that containers in your task may use | `list(string)` | `[]` | no |
+| volumes | A list of volume definitions in JSON format that containers in your task may use | `list(any)` | `[]` | no |
 | volumesFrom | Data volumes to mount from another container | `list(string)` | `[]` | no |
 | workingDirectory | The working directory in which to run commands inside the container | `string` | `""` | no |
 

--- a/examples/ecs_update_service.tf
+++ b/examples/ecs_update_service.tf
@@ -8,7 +8,10 @@
 #
 #  $ terraform taint null_resource.update-service
 
-provider "aws" {}
+provider "aws" {
+  region  = "us-east-1"
+  version = "~> 2.0"
+}
 
 module "mongo-task-definition" {
   source = "github.com/mongodb/terraform-aws-ecs-task-definition"
@@ -28,12 +31,12 @@ module "mongo-task-definition" {
 resource "aws_ecs_service" "mongo" {
   cluster         = "mongo"
   name            = "mongo"
-  task_definition = "${module.mongo-task-definition.arn}"
+  task_definition = module.mongo-task-definition.arn
 }
 
 resource "null_resource" "update-service" {
   triggers = {
-    arn = "${module.mongo-task-definition.arn}"
+    arn = module.mongo-task-definition.arn
   }
 
   provisioner "local-exec" {

--- a/examples/terraform-task-definition-multiple-containers/main.tf
+++ b/examples/terraform-task-definition-multiple-containers/main.tf
@@ -38,12 +38,12 @@ module "merged" {
   source = "../../modules/merge"
 
   container_definitions = [
-    "${module.mongodb.container_definitions}",
-    "${module.redis.container_definitions}",
+    module.mongodb.container_definitions,
+    module.redis.container_definitions,
   ]
 }
 
 resource "aws_ecs_task_definition" "ecs_task_definition" {
-  container_definitions = "${module.merged.container_definitions}"
+  container_definitions = module.merged.container_definitions
   family                = "app"
 }

--- a/main.tf
+++ b/main.tf
@@ -30,87 +30,51 @@
 #  - 4. https://github.com/hashicorp/terraform/issues/17033
 
 locals {
-  command               = "${jsonencode(var.command)}"
-  dnsSearchDomains      = "${jsonencode(var.dnsSearchDomains)}"
-  dnsServers            = "${jsonencode(var.dnsServers)}"
-  dockerLabels          = "${jsonencode(var.dockerLabels)}"
-  dockerSecurityOptions = "${jsonencode(var.dockerSecurityOptions)}"
-  entryPoint            = "${jsonencode(var.entryPoint)}"
-  environment           = "${jsonencode(var.environment)}"
-  extraHosts            = "${jsonencode(var.extraHosts)}"
+  command               = jsonencode(var.command)
+  dnsSearchDomains      = jsonencode(var.dnsSearchDomains)
+  dnsServers            = jsonencode(var.dnsServers)
+  dockerLabels          = jsonencode(var.dockerLabels)
+  dockerSecurityOptions = jsonencode(var.dockerSecurityOptions)
+  entryPoint            = jsonencode(var.entryPoint)
+  environment           = jsonencode(var.environment)
+  extraHosts            = jsonencode(var.extraHosts)
 
-  healthCheck = "${
+  healthCheck = replace(jsonencode(var.healthCheck), local.classes["digit"], "$1")
+
+  links = jsonencode(var.links)
+
+  linuxParameters = replace(
     replace(
-      jsonencode(var.healthCheck),
-      local.classes["digit"],
-      "$1"
-    )
-  }"
-
-  links = "${jsonencode(var.links)}"
-
-  linuxParameters = "${
-    replace(
-      replace(
-        replace(
-          jsonencode(var.linuxParameters),
-          "/\"1\"/",
-          "true"
-        ),
-        "/\"0\"/",
-        "false"
-      ),
-      local.classes["digit"],
-      "$1"
-    )
-  }"
-
-  logConfiguration = "${jsonencode(var.logConfiguration)}"
-
-  mountPoints = "${
-    replace(
-      replace(
-        jsonencode(var.mountPoints),
-        "/\"1\"/",
-        "true"
-      ),
+      replace(jsonencode(var.linuxParameters), "/\"1\"/", "true"),
       "/\"0\"/",
-      "false"
-    )
-  }"
+      "false",
+    ),
+    local.classes["digit"],
+    "$1",
+  )
 
-  portMappings = "${
-    replace(
-      jsonencode(var.portMappings),
-      local.classes["digit"],
-      "$1"
-    )
-  }"
+  logConfiguration = jsonencode(var.logConfiguration)
 
-  repositoryCredentials = "${jsonencode(var.repositoryCredentials)}"
-  resourceRequirements  = "${jsonencode(var.resourceRequirements)}"
-  secrets               = "${jsonencode(var.secrets)}"
-  systemControls        = "${jsonencode(var.systemControls)}"
+  mountPoints = replace(
+    replace(jsonencode(var.mountPoints), "/\"1\"/", "true"),
+    "/\"0\"/",
+    "false",
+  )
 
-  ulimits = "${
-    replace(
-      jsonencode(var.ulimits),
-      local.classes["digit"],
-      "$1"
-    )
-  }"
+  portMappings = replace(jsonencode(var.portMappings), local.classes["digit"], "$1")
 
-  volumesFrom = "${
-    replace(
-      replace(
-        jsonencode(var.volumesFrom),
-        "/\"1\"/",
-        "true"
-      ),
-      "/\"0\"/",
-      "false"
-    )
-  }"
+  repositoryCredentials = jsonencode(var.repositoryCredentials)
+  resourceRequirements  = jsonencode(var.resourceRequirements)
+  secrets               = jsonencode(var.secrets)
+  systemControls        = jsonencode(var.systemControls)
+
+  ulimits = replace(jsonencode(var.ulimits), local.classes["digit"], "$1")
+
+  volumesFrom = replace(
+    replace(jsonencode(var.volumesFrom), "/\"1\"/", "true"),
+    "/\"0\"/",
+    "false",
+  )
 
   # re2 ASCII character classes
   # https://github.com/google/re2/wiki/Syntax
@@ -118,89 +82,96 @@ locals {
     digit = "/\"(-[[:digit:]]|[[:digit:]]+)\"/"
   }
 
-  container_definition = "${
-    var.register_task_definition ?
-    format("[%s]", data.template_file.container_definition.rendered) :
-    format("%s", data.template_file.container_definition.rendered)
-  }"
+  container_definition = var.register_task_definition ? format("[%s]", data.template_file.container_definition.rendered) : format("%s", data.template_file.container_definition.rendered)
 
-  container_definitions = "${replace(local.container_definition, "/\"(null)\"/", "$1")}"
+  container_definitions = replace(local.container_definition, "/\"(null)\"/", "$1")
 }
 
 data "template_file" "container_definition" {
-  template = "${file("${path.module}/templates/container-definition.json.tpl")}"
+  template = file("${path.module}/templates/container-definition.json.tpl")
 
   vars = {
-    command                = "${local.command == "[]" ? "null" : local.command}"
-    cpu                    = "${var.cpu == 0 ? "null" : var.cpu}"
-    disableNetworking      = "${var.disableNetworking ? true : false}"
-    dnsSearchDomains       = "${local.dnsSearchDomains == "[]" ? "null" : local.dnsSearchDomains}"
-    dnsServers             = "${local.dnsServers == "[]" ? "null" : local.dnsServers}"
-    dockerLabels           = "${local.dockerLabels == "{}" ? "null" : local.dockerLabels}"
-    dockerSecurityOptions  = "${local.dockerSecurityOptions == "[]" ? "null" : local.dockerSecurityOptions}"
-    entryPoint             = "${local.entryPoint == "[]" ? "null" : local.entryPoint}"
-    environment            = "${local.environment == "[]" ? "null" : local.environment}"
-    essential              = "${var.essential ? true : false}"
-    extraHosts             = "${local.extraHosts == "[]" ? "null" : local.extraHosts}"
-    healthCheck            = "${local.healthCheck == "{}" ? "null" : local.healthCheck}"
-    hostname               = "${var.hostname == "" ? "null" : var.hostname}"
-    image                  = "${var.image == "" ? "null" : var.image}"
-    interactive            = "${var.interactive ? true : false}"
-    links                  = "${local.links == "[]" ? "null" : local.links}"
-    linuxParameters        = "${local.linuxParameters == "{}" ? "null" : local.linuxParameters}"
-    logConfiguration       = "${local.logConfiguration == "{}" ? "null" : local.logConfiguration}"
-    memory                 = "${var.memory == 0 ? "null" : var.memory}"
-    memoryReservation      = "${var.memoryReservation == 0 ? "null" : var.memoryReservation}"
-    mountPoints            = "${local.mountPoints == "[]" ? "null" : local.mountPoints}"
-    name                   = "${var.name == "" ? "null" : var.name}"
-    portMappings           = "${local.portMappings == "[]" ? "null" : local.portMappings}"
-    privileged             = "${var.privileged ? true : false}"
-    pseudoTerminal         = "${var.pseudoTerminal ? true : false}"
-    readonlyRootFilesystem = "${var.readonlyRootFilesystem ? true : false}"
-    repositoryCredentials  = "${local.repositoryCredentials == "{}" ? "null" : local.repositoryCredentials}"
-    resourceRequirements   = "${local.resourceRequirements == "[]" ? "null" : local.resourceRequirements}"
-    secrets                = "${local.secrets == "[]" ? "null" : local.secrets}"
-    systemControls         = "${local.systemControls == "[]" ? "null" : local.systemControls}"
-    ulimits                = "${local.ulimits == "[]" ? "null" : local.ulimits}"
-    user                   = "${var.user == "" ? "null" : var.user}"
-    volumesFrom            = "${local.volumesFrom == "[]" ? "null" : local.volumesFrom}"
-    workingDirectory       = "${var.workingDirectory == "" ? "null" : var.workingDirectory}"
+    command                = local.command == "[]" ? "null" : local.command
+    cpu                    = var.cpu == 0 ? "null" : var.cpu
+    disableNetworking      = var.disableNetworking ? true : false
+    dnsSearchDomains       = local.dnsSearchDomains == "[]" ? "null" : local.dnsSearchDomains
+    dnsServers             = local.dnsServers == "[]" ? "null" : local.dnsServers
+    dockerLabels           = local.dockerLabels == "{}" ? "null" : local.dockerLabels
+    dockerSecurityOptions  = local.dockerSecurityOptions == "[]" ? "null" : local.dockerSecurityOptions
+    entryPoint             = local.entryPoint == "[]" ? "null" : local.entryPoint
+    environment            = local.environment == "[]" ? "null" : local.environment
+    essential              = var.essential ? true : false
+    extraHosts             = local.extraHosts == "[]" ? "null" : local.extraHosts
+    healthCheck            = local.healthCheck == "{}" ? "null" : local.healthCheck
+    hostname               = var.hostname == "" ? "null" : var.hostname
+    image                  = var.image == "" ? "null" : var.image
+    interactive            = var.interactive ? true : false
+    links                  = local.links == "[]" ? "null" : local.links
+    linuxParameters        = local.linuxParameters == "{}" ? "null" : local.linuxParameters
+    logConfiguration       = local.logConfiguration == "{}" ? "null" : local.logConfiguration
+    memory                 = var.memory == 0 ? "null" : var.memory
+    memoryReservation      = var.memoryReservation == 0 ? "null" : var.memoryReservation
+    mountPoints            = local.mountPoints == "[]" ? "null" : local.mountPoints
+    name                   = var.name == "" ? "null" : var.name
+    portMappings           = local.portMappings == "[]" ? "null" : local.portMappings
+    privileged             = var.privileged ? true : false
+    pseudoTerminal         = var.pseudoTerminal ? true : false
+    readonlyRootFilesystem = var.readonlyRootFilesystem ? true : false
+    repositoryCredentials  = local.repositoryCredentials == "{}" ? "null" : local.repositoryCredentials
+    resourceRequirements   = local.resourceRequirements == "[]" ? "null" : local.resourceRequirements
+    secrets                = local.secrets == "[]" ? "null" : local.secrets
+    systemControls         = local.systemControls == "[]" ? "null" : local.systemControls
+    ulimits                = local.ulimits == "[]" ? "null" : local.ulimits
+    user                   = var.user == "" ? "null" : var.user
+    volumesFrom            = local.volumesFrom == "[]" ? "null" : local.volumesFrom
+    workingDirectory       = var.workingDirectory == "" ? "null" : var.workingDirectory
   }
 }
 
 resource "aws_ecs_task_definition" "ecs_task_definition" {
-  container_definitions    = "${local.container_definitions}"
-  execution_role_arn       = "${var.execution_role_arn}"
-  family                   = "${var.family}"
-  ipc_mode                 = "${var.ipc_mode}"
-  network_mode             = "${var.network_mode}"
-  pid_mode                 = "${var.pid_mode}"
-  requires_compatibilities = "${var.requires_compatibilities}"
-  task_role_arn            = "${var.task_role_arn}"
-  
-  dynamic "volume" {
-    for_each = [for v in var.volumes : {
-      name       = v.name
-      host_path  = v.host_path
-    }]
-
-    content {
-      name      = volume.value.name
-      host_path = volume.value.host_path
-    }
-  }
-
+  container_definitions = local.container_definitions
+  execution_role_arn    = var.execution_role_arn
+  family                = var.family
+  ipc_mode              = var.ipc_mode
+  network_mode          = var.network_mode
+  pid_mode              = var.pid_mode
   dynamic "placement_constraints" {
-    for_each = [for v in var.placement_constraints : {
-      type       = v.type
-      expression = v.expression
-    }]
-
+    for_each = var.placement_constraints
     content {
-      type      = volume.value.type
-      expression = volume.value.expression
+      # TF-UPGRADE-TODO: The automatic upgrade tool can't predict
+      # which keys might be set in maps assigned here, so it has
+      # produced a comprehensive set here. Consider simplifying
+      # this after confirming which keys can be set in practice.
+
+      expression = lookup(placement_constraints.value, "expression", null)
+      type       = placement_constraints.value.type
+    }
+  }
+  requires_compatibilities = var.requires_compatibilities
+  task_role_arn            = var.task_role_arn
+  dynamic "volume" {
+    for_each = var.volumes
+    content {
+      # TF-UPGRADE-TODO: The automatic upgrade tool can't predict
+      # which keys might be set in maps assigned here, so it has
+      # produced a comprehensive set here. Consider simplifying
+      # this after confirming which keys can be set in practice.
+
+      host_path = lookup(volume.value, "host_path", null)
+      name      = volume.value.name
+
+      dynamic "docker_volume_configuration" {
+        for_each = lookup(volume.value, "docker_volume_configuration", [])
+        content {
+          autoprovision = lookup(docker_volume_configuration.value, "autoprovision", null)
+          driver        = lookup(docker_volume_configuration.value, "driver", null)
+          driver_opts   = lookup(docker_volume_configuration.value, "driver_opts", null)
+          labels        = lookup(docker_volume_configuration.value, "labels", null)
+          scope         = lookup(docker_volume_configuration.value, "scope", null)
+        }
+      }
     }
   }
 
-  count = "${var.register_task_definition ? 1 : 0}"
+  count = var.register_task_definition ? 1 : 0
 }

--- a/modules/merge/README.md
+++ b/modules/merge/README.md
@@ -115,11 +115,15 @@ resource "aws_ecs_task_definition" "hello_world" {
 **Note:** The `register_task_definition` flag for both task definitions is required; otherwise a task definition containing a single container definition is registered created for both the `wordpress` and `mysql` services.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+No provider.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| container\_definitions | A list of container definitions in JSON format that describe the different containers that make up your task | list | `[]` | no |
+|------|-------------|------|---------|:-----:|
+| container\_definitions | A list of container definitions in JSON format that describe the different containers that make up your task | `list` | `[]` | no |
 
 ## Outputs
 

--- a/modules/merge/variables.tf
+++ b/modules/merge/variables.tf
@@ -1,5 +1,4 @@
 variable "container_definitions" {
   default     = []
   description = "A list of container definitions in JSON format that describe the different containers that make up your task"
-  type        = "list"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,20 @@
 output "arn" {
   description = "The full Amazon Resource Name (ARN) of the task definition"
-  value       = "${join("", aws_ecs_task_definition.ecs_task_definition.*.arn)}"
+  value       = join("", aws_ecs_task_definition.ecs_task_definition.*.arn)
 }
 
 output "container_definitions" {
   description = "A list of container definitions in JSON format that describe the different containers that make up your task"
-  value       = "${local.container_definitions}"
+  value       = local.container_definitions
 }
 
 output "family" {
   description = "The family of your task definition, used as the definition name"
-  value       = "${join("", aws_ecs_task_definition.ecs_task_definition.*.family)}"
+  value       = join("", aws_ecs_task_definition.ecs_task_definition.*.family)
 }
 
 output "revision" {
   description = "The revision of the task in a particular family"
-  value       = "${join("", aws_ecs_task_definition.ecs_task_definition.*.revision)}"
+  value       = join("", aws_ecs_task_definition.ecs_task_definition.*.revision)
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@
 variable "command" {
   default     = []
   description = "The command that is passed to the container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "cpu" {
@@ -20,37 +20,37 @@ variable "disableNetworking" {
 variable "dnsSearchDomains" {
   default     = []
   description = "A list of DNS search domains that are presented to the container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "dnsServers" {
   default     = []
   description = "A list of DNS servers that are presented to the container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "dockerLabels" {
   default     = {}
   description = "A key/value map of labels to add to the container"
-  type        = "map"
+  type        = map(string)
 }
 
 variable "dockerSecurityOptions" {
   default     = []
   description = "A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "entryPoint" {
   default     = []
   description = "The entry point that is passed to the container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "environment" {
   default     = []
   description = "The environment variables to pass to a container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "essential" {
@@ -66,7 +66,7 @@ variable "execution_role_arn" {
 variable "extraHosts" {
   default     = []
   description = "A list of hostnames and IP address mappings to append to the /etc/hosts file on the container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "family" {
@@ -76,7 +76,7 @@ variable "family" {
 variable "healthCheck" {
   default     = {}
   description = "The health check command and associated configuration parameters for the container"
-  type        = "map"
+  type        = map(string)
 }
 
 variable "hostname" {
@@ -102,19 +102,19 @@ variable "ipc_mode" {
 variable "links" {
   default     = []
   description = "The link parameter allows containers to communicate with each other without the need for port mappings"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "linuxParameters" {
   default     = {}
   description = "Linux-specific modifications that are applied to the container, such as Linux KernelCapabilities"
-  type        = "map"
+  type        = map(string)
 }
 
 variable "logConfiguration" {
   default     = {}
   description = "The log configuration specification for the container"
-  type        = "map"
+  type        = map(string)
 }
 
 variable "memory" {
@@ -130,7 +130,7 @@ variable "memoryReservation" {
 variable "mountPoints" {
   default     = []
   description = "The mount points for data volumes in your container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "name" {
@@ -151,13 +151,13 @@ variable "pid_mode" {
 variable "placement_constraints" {
   default     = []
   description = "An array of placement constraint objects to use for the task"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "portMappings" {
   default     = []
   description = "The list of port mappings for the container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "privileged" {
@@ -183,37 +183,37 @@ variable "register_task_definition" {
 variable "repositoryCredentials" {
   default     = {}
   description = "The private repository authentication credentials to use"
-  type        = "map"
+  type        = map(string)
 }
 
 variable "requires_compatibilities" {
   default     = []
   description = "The launch type required by the task"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "resourceRequirements" {
   default     = []
   description = "The type and amount of a resource to assign to a container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "secrets" {
   default     = []
   description = "The secrets to pass to the container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "systemControls" {
   default     = []
   description = "A list of namespaced kernel parameters to set in the container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "tags" {
   default     = {}
   description = "The metadata that you apply to the task definition to help you categorize and organize them"
-  type        = "map"
+  type        = map(string)
 }
 
 variable "task_role_arn" {
@@ -224,7 +224,7 @@ variable "task_role_arn" {
 variable "ulimits" {
   default     = []
   description = "A list of ulimits to set in the container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "user" {
@@ -235,16 +235,17 @@ variable "user" {
 variable "volumes" {
   default     = []
   description = "A list of volume definitions in JSON format that containers in your task may use"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "volumesFrom" {
   default     = []
   description = "Data volumes to mount from another container"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "workingDirectory" {
   default     = ""
   description = "The working directory in which to run commands inside the container"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "entryPoint" {
 variable "environment" {
   default     = []
   description = "The environment variables to pass to a container"
-  type        = list(string)
+  type        = list(map(string))
 }
 
 variable "essential" {
@@ -76,7 +76,7 @@ variable "family" {
 variable "healthCheck" {
   default     = {}
   description = "The health check command and associated configuration parameters for the container"
-  type        = map(string)
+  type        = any
 }
 
 variable "hostname" {
@@ -108,7 +108,7 @@ variable "links" {
 variable "linuxParameters" {
   default     = {}
   description = "Linux-specific modifications that are applied to the container, such as Linux KernelCapabilities"
-  type        = map(string)
+  type        = any
 }
 
 variable "logConfiguration" {
@@ -130,7 +130,7 @@ variable "memoryReservation" {
 variable "mountPoints" {
   default     = []
   description = "The mount points for data volumes in your container"
-  type        = list(string)
+  type        = list(any)
 }
 
 variable "name" {
@@ -157,7 +157,7 @@ variable "placement_constraints" {
 variable "portMappings" {
   default     = []
   description = "The list of port mappings for the container"
-  type        = list(string)
+  type        = list(any)
 }
 
 variable "privileged" {
@@ -224,7 +224,7 @@ variable "task_role_arn" {
 variable "ulimits" {
   default     = []
   description = "A list of ulimits to set in the container"
-  type        = list(string)
+  type        = list(any)
 }
 
 variable "user" {
@@ -235,7 +235,7 @@ variable "user" {
 variable "volumes" {
   default     = []
   description = "A list of volume definitions in JSON format that containers in your task may use"
-  type        = list(string)
+  type        = list(any)
 }
 
 variable "volumesFrom" {
@@ -248,4 +248,3 @@ variable "workingDirectory" {
   default     = ""
   description = "The working directory in which to run commands inside the container"
 }
-

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This pull request uses the [`0.12upgrade`](https://www.terraform.io/docs/commands/0.12upgrade.html) command to upgrade the configuration syntax to HCL 2.0.

BREAKING CHANGE:

This module no longer supports Terraform versions less than 0.11.x. Please upgrade to version `~> 0.12` of Terraform to continue using this module.

As always, please open an issue if more problems arise.

Closes #15, closes #20 