### PR TITLE
fix: update type of logConfiguration variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ By default, this module creates a task definition with a single container defini
 | ipc\_mode | The IPC resource namespace to use for the containers in the task | `string` | `"host"` | no |
 | links | The link parameter allows containers to communicate with each other without the need for port mappings | `list(string)` | `[]` | no |
 | linuxParameters | Linux-specific modifications that are applied to the container, such as Linux KernelCapabilities | `any` | `{}` | no |
-| logConfiguration | The log configuration specification for the container | `map(string)` | `{}` | no |
+| logConfiguration | The log configuration specification for the container | `any` | `{}` | no |
 | memory | The hard limit (in MiB) of memory to present to the container | `number` | `0` | no |
 | memoryReservation | The soft limit (in MiB) of memory to reserve for the container | `number` | `0` | no |
 | mountPoints | The mount points for data volumes in your container | `list(any)` | `[]` | no |

--- a/examples/terraform-task-definition-multiple-containers/main.tf
+++ b/examples/terraform-task-definition-multiple-containers/main.tf
@@ -22,7 +22,16 @@ module "redis" {
   family = "redis"
   image  = "redis:alpine"
   memory = 512
-  name   = "redis"
+
+  logConfiguration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group  = "awslogs-mongodb"
+      awslogs-region = "us-east-1"
+    }
+  }
+
+  name = "redis"
 
   portMappings = [
     {

--- a/test/fixtures/multiple.json
+++ b/test/fixtures/multiple.json
@@ -58,7 +58,13 @@
     "interactive": false,
     "links": null,
     "linuxParameters": null,
-    "logConfiguration": null,
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "awslogs-mongodb",
+        "awslogs-region": "us-east-1"
+      }
+    },
     "memory": 512,
     "memoryReservation": null,
     "mountPoints": null,

--- a/test/fixtures/single.json
+++ b/test/fixtures/single.json
@@ -61,7 +61,13 @@
         }
       ]
     },
-    "logConfiguration": null,
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "awslogs-mongodb",
+        "awslogs-region": "us-east-1"
+      }
+    },
     "memory": null,
     "memoryReservation": 512,
     "mountPoints": [

--- a/varfile.tfvars
+++ b/varfile.tfvars
@@ -43,6 +43,14 @@ linuxParameters = {
   ]
 }
 
+logConfiguration = {
+  logDriver = "awslogs"
+  options = {
+    awslogs-group  = "awslogs-mongodb"
+    awslogs-region = "us-east-1"
+  }
+}
+
 memoryReservation = 512
 
 mountPoints = [

--- a/variables.tf
+++ b/variables.tf
@@ -114,7 +114,7 @@ variable "linuxParameters" {
 variable "logConfiguration" {
   default     = {}
   description = "The log configuration specification for the container"
-  type        = map(string)
+  type        = any
 }
 
 variable "memory" {


### PR DESCRIPTION
Updates the type for the `logConfiguration` variable from:

```diff
- map(string)
+ any
```

Also updates the fixtures in the `test` directory to contain `logConfiguration` directives.

Fixes #26