### PR TITLE
fix: variable type def for placement constraints

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -157,7 +157,10 @@ variable "pid_mode" {
 variable "placement_constraints" {
   default     = []
   description = "An array of placement constraint objects to use for the task"
-  type        = list(string)
+  type = list(object({
+    type       = string
+    expression = string
+  }))
 }
 
 variable "portMappings" {


### PR DESCRIPTION
this is a fix for the second part of the bug described in https://github.com/mongodb/terraform-aws-ecs-task-definition/issues/33