### PR TITLE
fix(task-definition): update volumesFrom data type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -247,7 +247,11 @@ variable "volumes" {
 variable "volumesFrom" {
   default     = []
   description = "Data volumes to mount from another container"
-  type        = list(string)
+
+  type = list(object({
+    readOnly        = bool
+    sourceContainer = string
+  }))
 }
 
 variable "workingDirectory" {


### PR DESCRIPTION
The `volumesFrom` data type is an object array with `sourceContainer`
and `readOnly` fields.

Resolves #41 