### PR TITLE
Fix Secrets Variable Type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -207,7 +207,7 @@ variable "resourceRequirements" {
 variable "secrets" {
   default     = []
   description = "The secrets to pass to the container"
-  type        = list(string)
+  type        = list(map(string))
 }
 
 variable "systemControls" {


### PR DESCRIPTION
## overview
Change secrets variable per aws secrets definition: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Secret.html

This also corresponds to an old closed issue that was never PR'd: https://github.com/mongodb/terraform-aws-ecs-task-definition/issues/43