### PR TITLE
Add configuration fields for EFS volumes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -178,8 +178,18 @@ resource "aws_ecs_task_definition" "ecs_task_definition" {
       dynamic "efs_volume_configuration" {
         for_each = lookup(volume.value, "efs_volume_configuration", [])
         content {
-          file_system_id = lookup(efs_volume_configuration.value, "file_system_id", null)
-          root_directory = lookup(efs_volume_configuration.value, "root_directory", null)
+          file_system_id          = lookup(efs_volume_configuration.value, "file_system_id", null)
+          root_directory          = lookup(efs_volume_configuration.value, "root_directory", null)
+          transit_encryption      = lookup(efs_volume_configuration.value, "transit_encryption", null)
+          transit_encryption_port = lookup(efs_volume_configuration.value, "transit_encryption_port", null)
+
+          dynamic "authorization_config" {
+            for_each = lookup(efs_volume_configuration.value, "authorization_config", null) != null ? [efs_volume_configuration.value.authorization_config] : []
+            content {
+              access_point_id = lookup(authorization_config.value, "access_point_id", null)
+              iam             = lookup(authorization_config.value, "iam", null)
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
As per [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition#efs-volume-configuration-arguments), the `efs_volume_configuration` does support more fields than the one specified in this module. 
This PR aims to align the module with the official resource.