### PR TITLE
Module is failing tfsec security parsing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,6 @@ locals {
 
   repositoryCredentials = jsonencode(var.repositoryCredentials)
   resourceRequirements  = jsonencode(var.resourceRequirements)
-  secrets               = jsonencode(var.secrets)
   systemControls        = jsonencode(var.systemControls)
 
   ulimits = replace(jsonencode(var.ulimits), local.classes["digit"], "$1")
@@ -119,7 +118,7 @@ data "template_file" "container_definition" {
     readonlyRootFilesystem = var.readonlyRootFilesystem ? true : false
     repositoryCredentials  = local.repositoryCredentials == "{}" ? "null" : local.repositoryCredentials
     resourceRequirements   = local.resourceRequirements == "[]" ? "null" : local.resourceRequirements
-    secrets                = local.secrets == "[]" ? "null" : local.secrets
+    secrets                = jsonencode(var.secrets) == "[]" ? "null" : jsonencode(var.secrets) // do not parse secrets via a local var
     systemControls         = local.systemControls == "[]" ? "null" : local.systemControls
     ulimits                = local.ulimits == "[]" ? "null" : local.ulimits
     user                   = var.user == "" ? "null" : var.user


### PR DESCRIPTION
The module is currently failing the `tfsec` security parser on rule `GEN002` because a secret is being stored in the local variable. This should be parsed directly to the resource.

`[GEN002][WARNING] Local 'locals.' includes a potentially sensitive value that is defined within the project.`

For more info see: https://tfsec.dev/docs/general/GEN002/