### PR TITLE
Add runtime_platform variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,6 +135,10 @@ resource "aws_ecs_task_definition" "ecs_task_definition" {
   ipc_mode              = var.ipc_mode
   network_mode          = var.network_mode
   pid_mode              = var.pid_mode
+  runtime_platform {
+    operating_system_family = var.runtime_platform.operating_system_family
+    cpu_architecture        = var.runtime_platform.cpu_architecture
+  }
 
   # Fargate requires cpu and memory to be defined at the task level
   cpu    = var.cpu

--- a/variables.tf
+++ b/variables.tf
@@ -207,6 +207,15 @@ variable "resourceRequirements" {
   type        = list(string)
 }
 
+variable "runtime_platform" {
+  default = {}
+  description = "Runtime platform (operating system family and CPU architecture) to use by the task"
+  type = object({
+    operating_system_family = optional(string, "LINUX")
+    cpu_architecture       = optional(string, "X86_64")
+  })
+}
+
 variable "secrets" {
   default     = []
   description = "The secrets to pass to the container"


### PR DESCRIPTION
This pull request introduces the runtime_platform variable to the AWS Fargate Task Definition Terraform module. 

By adding these parameters, we enable specifying the operating system family (such as LINUX or WINDOWS) at the runtime platform level, enhancing flexibility and supporting Fargate features for both Linux and Windows containers while keeping backward compatibility with linux default value.
